### PR TITLE
Exclude file name from detect common prefix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,10 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ngzip.gemspec
+group :test do
+  gem 'minitest'
+  gem 'minitest-reporters'
+  gem 'pry'
+end
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['test/lib/ngzip/*_test.rb']
   t.verbose = true
 end
- 
+
 task :default => :test

--- a/lib/ngzip/builder.rb
+++ b/lib/ngzip/builder.rb
@@ -1,5 +1,6 @@
 require 'zlib'
 require 'uri'
+require 'erb'
 
 module Ngzip
   class Builder
@@ -44,7 +45,7 @@ module Ngzip
     #
     # Returns the encoded string using URL escape formatting
     def self.encode(string)
-      URI.encode(string).gsub('+', '%2B').gsub('?', '%3F')
+      ERB::Util.url_encode(string)
     end
 
     private

--- a/lib/ngzip/builder.rb
+++ b/lib/ngzip/builder.rb
@@ -26,10 +26,10 @@ module Ngzip
       prefix += '/' unless prefix.end_with?('/')
       list.map do |f|
         sprintf('%s %d %s %s',
-                compute_crc32(f, settings),
-                File.size(f).to_i,
-                Builder.encode(f),
-                f.gsub(prefix, '')
+          compute_crc32(f, settings),
+          File.size(f).to_i,
+          Builder.encode(f),
+          f.gsub(prefix, ''),
         )
       end.join("\n")
     end
@@ -37,7 +37,7 @@ module Ngzip
     # Public: Get the special header to signal the mod_zip
     #
     # Returns the header as a string "key: value"
-    def header()
+    def header
       "X-Archive-Files: zip"
     end
 
@@ -98,7 +98,7 @@ module Ngzip
 
       # read using a buffer, we might operate on large files!
       crc32 = 0
-      File.open(file,'rb') do |f|
+      File.open(file, 'rb') do |f|
         while buffer = f.read(BUFFER_SIZE) do
           crc32 = Zlib.crc32(buffer, crc32)
         end

--- a/lib/ngzip/builder.rb
+++ b/lib/ngzip/builder.rb
@@ -59,7 +59,8 @@ module Ngzip
         return File.dirname(list.first)
       end
       prefix = ''
-      min, max = list.sort.values_at(0, -1)
+      excluding_file_names = list.map { |p| File.dirname p }
+      min, max = excluding_file_names.sort.values_at(0, -1)
       min.split(//).each_with_index do |c, i|
         break if c != max[i, 1]
         prefix << c

--- a/lib/ngzip/builder.rb
+++ b/lib/ngzip/builder.rb
@@ -74,7 +74,9 @@ module Ngzip
     def file_list(files)
       Array(files).map do |e|
         if File.directory?(e)
-          Dir.glob("#{e}/**/*").reject { |f| File.directory?(f) }
+          # `expand_path` removes any trailing slash from the path string
+          sanitized_path = File.expand_path(e)
+          Dir.glob("#{sanitized_path}/**/*").reject { |f| File.directory?(f) }
         else
           e
         end

--- a/test/lib/ngzip/builder_test.rb
+++ b/test/lib/ngzip/builder_test.rb
@@ -107,6 +107,22 @@ describe Ngzip::Builder do
       pathes.must_equal expected
     end
 
+    describe "when building the manifest from a directory path parameter" do
+      it "removes trailing slash from builder file path" do
+        dir_path = File.join(File.dirname(lorem), '/')
+        result = builder.build(dir_path)
+        encoded_host_path = ERB::Util.url_encode(File.join(File.expand_path('../../data', File.dirname(__FILE__)), '/'))
+        manifest = <<-MANIFEST.chomp
+8f92322f 446 #{encoded_host_path}a%2FA%20filename%20with%20whitespace.txt A filename with whitespace.txt
+8f92322f 446 #{encoded_host_path}a%2Ffilename-without-a-dot filename-without-a-dot
+8f92322f 446 #{encoded_host_path}a%2Fipsum.txt ipsum.txt
+8f92322f 446 #{encoded_host_path}a%2Florem.txt lorem.txt
+8f92322f 446 #{encoded_host_path}a%2Fd%2Fmy_file.txt d/my_file.txt
+MANIFEST
+        expect(result).must_equal manifest
+      end
+    end
+
     it 'must keep common directories if :base_dir is provided' do
       options = {:base_dir => Pathname.new(lorem).parent.parent.to_s}
       pathes = builder.build([lorem, ipsum], options).split("\n").map { |line| line.split.last }

--- a/test/lib/ngzip/builder_test.rb
+++ b/test/lib/ngzip/builder_test.rb
@@ -5,23 +5,27 @@ require 'pathname'
 describe Ngzip do
 
   it 'must support the static method :build' do
-    Ngzip.respond_to?(:build).must_equal true
+    expect(Ngzip.respond_to?(:build)).must_equal true
   end
 
 end
 
 describe Ngzip::Builder do
 
-  let(:builder) {Ngzip::Builder.new()}
-  let(:lorem) {File.expand_path('../../../data/a/lorem.txt', __FILE__)}
-  let(:ipsum) {File.expand_path('../../../data/a/ipsum.txt', __FILE__)}
-  let(:without_dot) {File.expand_path('../../../data/a/filename-without-a-dot', __FILE__)}
-  let(:my_file) {File.expand_path('../../../data/a/d/my_file.txt', __FILE__)}
-  let(:whitespaced) {File.expand_path('../../../data/a/A filename with whitespace.txt', __FILE__)}
-  let(:plused) {File.expand_path('../../../data/c/A filename with space and + in it.txt', __FILE__)}
-  let(:cargo) {File.expand_path('../../../data/b/Cargo.png', __FILE__)}
-  let(:sit) {File.expand_path('../../../data/sit.txt', __FILE__)}
-  let(:a) {File.expand_path('../../../data/a', __FILE__)}
+  def encode_file_path(path)
+    ERB::Util.url_encode path
+  end
+
+  let(:builder) { Ngzip::Builder.new() }
+  let(:lorem) { File.expand_path('../../../data/a/lorem.txt', __FILE__) }
+  let(:ipsum) { File.expand_path('../../../data/a/ipsum.txt', __FILE__) }
+  let(:without_dot) { File.expand_path('../../../data/a/filename-without-a-dot', __FILE__) }
+  let(:my_file) { File.expand_path('../../../data/a/d/my_file.txt', __FILE__) }
+  let(:whitespaced) { File.expand_path('../../../data/a/A filename with whitespace.txt', __FILE__) }
+  let(:plused) { File.expand_path('../../../data/c/A filename with space and + in it.txt', __FILE__) }
+  let(:cargo) { File.expand_path('../../../data/b/Cargo.png', __FILE__) }
+  let(:sit) { File.expand_path('../../../data/sit.txt', __FILE__) }
+  let(:a) { File.expand_path('../../../data/a', __FILE__) }
   let(:questions) { File.expand_path('../../../data/c/questions?', __FILE__) }
 
   it 'must be defined' do
@@ -37,97 +41,96 @@ describe Ngzip::Builder do
   end
 
   describe "with CRC-32 checksums disabled" do
-    let(:options) { {:crc => false}}
+    let(:options) { {:crc => false} }
 
     it 'must return a correct list for one file' do
-      expected = "- 446 #{lorem} lorem.txt"
+      expected = "- 446 #{encode_file_path(lorem)} lorem.txt"
       builder.build(lorem, options).must_equal expected
     end
   end
 
   describe "with CRC-32 checksums enabled" do
-    let(:options) { {:crc => true}}
+    let(:options) { {:crc => true} }
 
     it 'must return a correct list for one file with a checksum' do
-      expected = "8f92322f 446 #{lorem} lorem.txt"
+      expected = "8f92322f 446 #{encode_file_path(lorem)} lorem.txt"
       builder.build(lorem, options).must_equal expected
     end
 
     it 'must return a correct list for one binary file with a checksum' do
-      expected = "b2f4655b 11550 #{cargo} Cargo.png"
+      expected = "b2f4655b 11550 #{encode_file_path(cargo)} Cargo.png"
       builder.build(cargo, options).must_equal expected
     end
 
     it 'must escape the path name' do
-      expected = "8f92322f 446 #{URI.escape(whitespaced)} A filename with whitespace.txt"
+      expected = "8f92322f 446 #{encode_file_path(whitespaced)} A filename with whitespace.txt"
       builder.build(whitespaced, options).must_equal expected
     end
 
     it 'must return a correct list for all files in a directory' do
-      expected = "8f92322f 446 #{URI.escape(whitespaced)} A filename with whitespace.txt"
-      expected << "\n8f92322f 446 #{my_file} d/my_file.txt"
-      expected << "\n8f92322f 446 #{without_dot} filename-without-a-dot"
-      expected << "\n8f92322f 446 #{ipsum} ipsum.txt"
-      expected << "\n8f92322f 446 #{lorem} lorem.txt"
-      builder.build(a,options).must_equal expected
+      expected = "8f92322f 446 #{encode_file_path(whitespaced)} A filename with whitespace.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(without_dot)} filename-without-a-dot"
+      expected << "\n8f92322f 446 #{encode_file_path(ipsum)} ipsum.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(lorem)} lorem.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(my_file)} d/my_file.txt"
+      builder.build(a, options).must_equal expected
     end
 
     it 'must allow to mix files and directories' do
-      expected = "8f92322f 446 #{URI.escape(whitespaced)} a/A filename with whitespace.txt"
-      expected << "\n8f92322f 446 #{my_file} a/d/my_file.txt"
-      expected << "\n8f92322f 446 #{without_dot} a/filename-without-a-dot"
-      expected << "\n8f92322f 446 #{ipsum} a/ipsum.txt"
-      expected << "\n8f92322f 446 #{lorem} a/lorem.txt"
-      expected << "\nf7c0867d 1342 #{sit} sit.txt"
-      builder.build([a,sit], options).must_equal expected
+      expected = "8f92322f 446 #{encode_file_path(whitespaced)} a/A filename with whitespace.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(without_dot)} a/filename-without-a-dot"
+      expected << "\n8f92322f 446 #{encode_file_path(ipsum)} a/ipsum.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(lorem)} a/lorem.txt"
+      expected << "\n8f92322f 446 #{encode_file_path(my_file)} a/d/my_file.txt"
+      expected << "\nf7c0867d 1342 #{encode_file_path(sit)} sit.txt"
+      builder.build([a, sit], options).must_equal expected
     end
 
     it 'must preserve directory names' do
       expected = [
-        "8f92322f 446 #{lorem} a/lorem.txt",
-        "8f92322f 446 #{ipsum} a/ipsum.txt",
-        "b2f4655b 11550 #{cargo} b/Cargo.png"
-        ].join("\n")
-      builder.build([lorem,ipsum,cargo], options).must_equal expected
+        "8f92322f 446 #{encode_file_path(lorem)} a/lorem.txt",
+        "8f92322f 446 #{encode_file_path(ipsum)} a/ipsum.txt",
+        "b2f4655b 11550 #{encode_file_path(cargo)} b/Cargo.png"
+      ].join("\n")
+      builder.build([lorem, ipsum, cargo], options).must_equal expected
     end
 
     it 'must honor the CRC cache' do
       invalid_but_cached = "781aaabcc124"
-      expected = "#{invalid_but_cached} 446 #{lorem} lorem.txt"
+      expected = "#{invalid_but_cached} 446 #{encode_file_path(lorem)} lorem.txt"
       builder.build(lorem, options.merge(:crc_cache => {lorem => invalid_but_cached})).must_equal expected
     end
 
     it 'must remove common directories by default' do
-      pathes = builder.build([lorem, ipsum]).split("\n").map{|line| line.split.last}
+      pathes = builder.build([lorem, ipsum]).split("\n").map { |line| line.split.last }
       expected = ["lorem.txt", "ipsum.txt"]
       pathes.must_equal expected
     end
 
     it 'must keep common directories if :base_dir is provided' do
       options = {:base_dir => Pathname.new(lorem).parent.parent.to_s}
-      pathes = builder.build([lorem, ipsum], options).split("\n").map{|line| line.split.last}
+      pathes = builder.build([lorem, ipsum], options).split("\n").map { |line| line.split.last }
       expected = ["a/lorem.txt", "a/ipsum.txt"]
       pathes.must_equal expected
     end
 
     it 'must cope with a trailing / in the :base_dir' do
       options = {:base_dir => Pathname.new(lorem).parent.parent.to_s + '/'}
-      pathes = builder.build([lorem, ipsum], options).split("\n").map{|line| line.split.last}
+      pathes = builder.build([lorem, ipsum], options).split("\n").map { |line| line.split.last }
       expected = ["a/lorem.txt", "a/ipsum.txt"]
       pathes.must_equal expected
     end
 
     it 'must correctly encode filenames with a "+"' do
       options = {}
-      name = File.join(Pathname.new(plused).parent.to_s, 'A%20filename%20with%20space%20and%20%2B%20in%20it.txt')
-      expected = "8f92322f 446 #{name} A filename with space and + in it.txt"
+      name = File.join(Pathname.new(plused).parent.to_s, 'A filename with space and + in it.txt')
+      expected = "8f92322f 446 #{encode_file_path(name)} A filename with space and + in it.txt"
       builder.build([plused], options).must_equal expected
     end
 
     it 'must correctly encode the "?" character' do
-      name = File.join(Pathname.new(questions).parent.to_s, 'questions%3F/test.txt')
-      expected = "f03102f5 13 #{name} test.txt"
-
+      name = File.join(Pathname.new(questions).parent.to_s, 'questions?/test.txt')
+      expected = "f03102f5 13 #{encode_file_path(name)} test.txt"
       builder.build([File.join(questions, 'test.txt')]).must_equal expected
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'minitest/reporters'
+require 'pry'
+Minitest::Reporters.use!
 require File.expand_path('../../lib/ngzip.rb', __FILE__)
 


### PR DESCRIPTION
## Current Behavior

Due to `detect_common_prefix` implementation, it is possible to return a 'common prefix' that includes shared portions of the actual file names contained in the files list.

However, looking at the code in the `build` method and specifically at how [the prefix is assumed to be a path](https://github.com/cargoserver/ngzip/blob/master/lib/ngzip/builder.rb#L25), it seems as if the intention is to automatically include any shared _leading path_ prefixes without looking into the file names.

I also changed the `encode` method to use `ERB::Util.url_encode` as that is more idiomatic these days in Ruby; and made some small noop formatting changes.